### PR TITLE
Ignore accents when sorting the parsed text

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Or install it yourself as:
 ```
 
 ### Arguments (hash)
-| Key                                     | Type   | Default value |
-| --------------------------------------- | ------ | ------------- |
-| :dictionary                             | Array  | nil           |
-| :order (:word, :hits)                   | Symbol | :word         |
-| :order_direction (:asc, :desc)          | Symbol | :asc          |
-| :order_style (:ignore_accents, :ascii ) | Symbol | :ascii        |
-| :negative_dictionary                    | Array  | nil           |
-| :minimum_length                         | int    | nil           |
+| Key                                     | Type   | Default value   |
+| --------------------------------------- | ------ | --------------- |
+| :dictionary                             | Array  | nil             |
+| :order (:word, :hits)                   | Symbol | :word           |
+| :order_direction (:asc, :desc)          | Symbol | :asc            |
+| :order_style (:ignore_accents, :ascii ) | Symbol | :ignore_accents |
+| :negative_dictionary                    | Array  | nil             |
+| :minimum_length                         | int    | nil             |
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -44,20 +44,21 @@ Or install it yourself as:
 ```
 
 ### Arguments (hash)
-| Key                             | Type   | Default value |
-| ------------------------------- | ------ | ------------- |
-| :dictionary                     | Array  | nil           |
-| :order (:word, :hits)           | Symbol | :word         |
-| :order_direction (:asc, :desc)  | Symbol | :asc          |
-| :negative_dictionary            | Array  | nil           |
-| :minimum_length                 | int    | nil           |
+| Key                                     | Type   | Default value |
+| --------------------------------------- | ------ | ------------- |
+| :dictionary                             | Array  | nil           |
+| :order (:word, :hits)                   | Symbol | :word         |
+| :order_direction (:asc, :desc)          | Symbol | :asc          |
+| :order_style (:ignore_accents, :ascii ) | Symbol | :ascii        |
+| :negative_dictionary                    | Array  | nil           |
+| :minimum_length                         | int    | nil           |
 
 
 ## Contributing
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Run the tests
+3. Run the tests (`rake test`)
 4. Commit your changes (`git commit -am 'Add some feature'`)
 5. Push to the branch (`git push origin my-new-feature`)
 6. Create new Pull Request

--- a/lib/text_parser.rb
+++ b/lib/text_parser.rb
@@ -1,31 +1,47 @@
 # -*- encoding : utf-8 -*-
-require_relative "text_parser/version"
+require_relative 'text_parser/version'
 
 module TextParser
+  TEXT_PARSER_OPTIONS = {
+    :order => :word,
+    :order_direction => :asc,
+    :order_style => :ascii,
+    :negative_dictionary => []
+  }.freeze
+
   # Returns a parsed text with the words and its occurrences.
   # @param [Hash] [args]
-  # [args] [Symbol] :dictionary, :order, :order_direction, :negative_dictionary
+  # [args] [Symbol] :dictionary, :order, :order_direction, :order_style, :negative_dictionary
   # @return [Array of Hash]
   def parse(args = {})
-    args.delete_if {|key, value| value.nil? }
-    options = {
-      :order => :word,
-      :order_direction => :asc,
-      :negative_dictionary => []
-    }.merge(args)
-    result = []
-    text = self.gsub(/[^A-Za-zÀ-ú0-9\-]/u," ").strip
-    options[:dictionary] = text.split(" ") unless options[:dictionary]
+    args.delete_if { |key, value| value.nil? }
+    options = TEXT_PARSER_OPTIONS.merge(args)
+    text = self.gsub(/[^A-Za-zÀ-ú0-9\-]/u,' ').strip
+    options[:dictionary] = text.split(' ') unless options[:dictionary]
     return [] if options[:dictionary].count < 1
     regex = Regexp.new(options[:dictionary].join('\\b|\\b'), Regexp::IGNORECASE)
     match_result = text.scan(regex).map{|i| i.downcase}
     match_result = match_result.select{|i| i.size >= options[:minimum_length]} if options[:minimum_length]
+    result = []
     match_result.each do |w|
-      result << {:hits => match_result.count(w), :word => w} unless result.select{|r| r[:word] == w}.shift || options[:negative_dictionary].map{|i| i.downcase}.include?(w)
+      result << { :hits => match_result.count(w), :word => w } unless result.select { |r| r[:word] == w}.shift || options[:negative_dictionary].map{|i| i.downcase }.include?(w)
     end
-    result = result.sort_by{|i| i[options[:order]]}
+
+    result.sort_by! do |i|
+      current_item = i[options[:order]]
+      ignore_accents = options[:order_style] == :ignore_accents && current_item.is_a?(String)
+
+      ignore_accents ? current_item.without_accents : current_item
+    end
     result.reverse! if options[:order_direction] == :desc
+
     result
+  end
+
+  def without_accents
+    self.tr(
+      'ÀÁÂÃÄÅàáâãäåĀāĂăĄąÇçĆćĈĉĊċČčÐðĎďĐđÈÉÊËèéêëĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħÌÍÎÏìíîïĨĩĪīĬĭĮįİıĴĵĶķĸĹĺĻļĽľĿŀŁłÑñŃńŅņŇňŉŊŋÒÓÔÕÖØòóôõöøŌōŎŏŐőŔŕŖŗŘřŚśŜŝŞşŠšȘșſŢţŤťŦŧȚțÙÚÛÜùúûüŨũŪūŬŭŮůŰűŲųŴŵÝýÿŶŷŸŹźŻżŽž',
+      'AAAAAAaaaaaaAaAaAaCcCcCcCcCcDdDdDdEEEEeeeeEeEeEeEeEeGgGgGgGgHhHhIIIIiiiiIiIiIiIiIiJjKkkLlLlLlLlLlNnNnNnNnnNnOOOOOOooooooOoOoOoRrRrRrSsSsSsSsSssTtTtTtTtUUUUuuuuUuUuUuUuUuUuWwYyyYyYZzZzZz')
   end
 end
 

--- a/lib/text_parser.rb
+++ b/lib/text_parser.rb
@@ -5,7 +5,7 @@ module TextParser
   TEXT_PARSER_OPTIONS = {
     :order => :word,
     :order_direction => :asc,
-    :order_style => :ascii,
+    :order_style => :ignore_accents,
     :negative_dictionary => []
   }.freeze
 
@@ -16,7 +16,7 @@ module TextParser
   def parse(args = {})
     args.delete_if { |key, value| value.nil? }
     options = TEXT_PARSER_OPTIONS.merge(args)
-    text = self.gsub(/[^A-Za-zÀ-ú0-9\-]/u,' ').strip
+    text = self.gsub(/[^A-Za-zÀ-ú0-9\-]/u, ' ').strip
     options[:dictionary] = text.split(' ') unless options[:dictionary]
     return [] if options[:dictionary].count < 1
     regex = Regexp.new(options[:dictionary].join('\\b|\\b'), Regexp::IGNORECASE)

--- a/test/text_parser_test.rb
+++ b/test/text_parser_test.rb
@@ -1,9 +1,8 @@
 # -*- encoding : utf-8 -*-
-require "test/unit"
-require "text_parser"
+require 'test/unit'
+require 'text_parser'
 
 class TextParserTest < Test::Unit::TestCase
-
   def test_should_have_method_parse
     assert "string".respond_to?(:parse)
   end
@@ -29,7 +28,7 @@ class TextParserTest < Test::Unit::TestCase
   end
 
   def test_should_order_by_word_asc
-    text = " beta omega gamma alpha gamma"
+    text = ' beta omega gamma alpha gamma'
     result = [{:word => "alpha",  :hits => 1},
               {:word => "beta",   :hits => 1},
               {:word => "gamma",  :hits => 2},
@@ -41,7 +40,48 @@ class TextParserTest < Test::Unit::TestCase
 
   def test_should_order_by_word_desc
     assert_equal [{:word => "zzz",  :hits => 1},
-                  {:word => "aaa",  :hits => 1}], "aaa zzz".parse(:order => :word, :order_direction => :desc)
+                  {:word => "aaa",  :hits => 1}], 'aaa zzz'.parse(:order => :word, :order_direction => :desc)
+  end
+
+  def test_should_order_ignoring_accents
+    text = 'bílis ômega gato astuto árvore amora gato'
+    result = [
+      { :word => 'amora', :hits => 1 },
+      { :word => 'árvore', :hits => 1 },
+      { :word => 'astuto', :hits => 1 },
+      { :word => 'bílis', :hits => 1 },
+      { :word => 'gato', :hits => 2 },
+      { :word => 'ômega', :hits => 1 }
+    ]
+
+    assert_equal result, text.parse(:order => :word, :order_style => :ignore_accents)
+  end
+
+  def test_should_order_ignoring_accents_desc
+    text = 'bílis ômega gato árvore amora gato'
+    result = [
+      { :word => 'ômega', :hits => 1 },
+      { :word => 'gato', :hits => 2 },
+      { :word => 'bílis', :hits => 1 },
+      { :word => 'árvore', :hits => 1 },
+      { :word => 'amora', :hits => 1 }
+    ]
+
+    assert_equal result, text.parse(:order => :word, :order_style => :ignore_accents, :order_direction => :desc)
+  end
+
+  def test_should_not_ignore_accents_if_ordered_field_is_not_string
+    text = 'bílis ômega gato astuto árvore amora gato'
+    result = [
+      { :word => 'gato', :hits => 2 },
+      { :word => 'amora', :hits => 1 },
+      { :word => 'árvore', :hits => 1 },
+      { :word => 'astuto', :hits => 1 },
+      { :word => 'bílis', :hits => 1 },
+      { :word => 'ômega', :hits => 1 }
+    ]
+    parsed_text = text.parse(:order => :hits, :order_style => :ignore_accents, :order_direction => :desc)
+    assert_equal 'gato', parsed_text.first[:word]
   end
 
   def test_should_order_by_hits_asc


### PR DESCRIPTION
Nowadays, the Text Parser gem has a feature that allows us to sort the most frequently used words. However, the sort does not behave as expected when the words have accents (some languages are full of them). 

This PR adds an extra functionality, the `order_style`. If you pass `:ignore_accents` to it, all the accents are removed prior to the sorting mechanism (and don't worry, the original words are not affected). The default style is `ascii`, keeping the current behaviour.

One important issue: this feature works only for strings, since I can't remove accents from a number, for example. There was the possibility to use a `to_s`, but that would screw the order criteria, so I opted to disregard the order style of the order field is not a String. 

Let me know if this behaviour is 👍 