### PR TITLE
Bump ruby version and change ruby sintaxe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     docker:
        - image: circleci/ruby:1.9.2
+       - image: circleci/ruby:2.4.1
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-       - image: circleci/ruby:2.4.1
+       - image: circleci/ruby:1.9.2
 
     working_directory: ~/repo
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ Using method parse in the String object you can parse any text.
 [![CircleCI](https://circleci.com/gh/fpaula/text_parser/tree/master.svg?style=svg)](https://circleci.com/gh/fpaula/text_parser/tree/master)
 [![Gem Version](https://badge.fury.io/rb/text_parser.svg)](https://badge.fury.io/rb/text_parser)
 
-## Installation
+## Dependencies
 
+This gem requires ruby `1.9.2` or above.
+
+## Installation
 
 Add this line to your application's Gemfile:
 
@@ -22,25 +25,25 @@ Or install it yourself as:
 
 ## Usage
 ```ruby
-    "Simple, simple test".parse
-    # => [{:word => "simple", :hits => 2}, {:word => "test", :hits => 1}]
+    'Simple, simple test'.parse
+    # => [{ word: 'simple', hits: 2 }, { word: 'test', hits: 1 }]
 ```
 ```ruby
-    my_text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium consectetur."
-    my_text.parse(:dictionary => ["dolor", "consectetur"])
-    # => [{:word => "consectetur", :hits => 2}, {:word => "dolor", :hits => 1}]
+    my_text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium consectetur.'
+    my_text.parse(dictionary: ['dolor', 'consectetur'])
+    # => [{ word: 'consectetur', hits: 2 }, { word: 'dolor', hits: 1 }]
 ```
 ```ruby
-    my_text.parse(:dictionary => ["dolor", "consectetur"], :order => :word, :order_direction => :desc)
-    # => [{:word => "dolor", :hits => 1}, {:word => "consectetur", :hits => 2}]
+    my_text.parse(dictionary: ['dolor', 'consectetur'], order: :word, order_direction: :desc)
+    # => [{ word: 'dolor', hits: 1 }, { word: 'consectetur', hits: 2 }]
 ```
 ```ruby
-    "Lorem ipsum dolor sit amet".parse(:negative_dictionary => ["ipsum", "dolor", "sit"])
-    # => [{:word => "loren", :hits => 1}, {:word => "amet", :hits => 1}]
+    'Lorem ipsum dolor sit amet'.parse(negative_dictionary: ['ipsum', 'dolor', 'sit'])
+    # => [{ word: 'loren', hits: 1 }, { word: 'amet', hits: 1 }]
 ```
 ```ruby
-    "My test!".parse(:minimum_length => 3)
-    # => [{:word => "test", :hits => 1}]
+    'My test!'.parse(minimum_length: 3)
+    # => [{ word: 'test', hits: 1 }]
 ```
 
 ### Arguments (hash)

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,9 @@
-require "bundler/gem_tasks"
-require "rake/testtask"
+require 'bundler/gem_tasks'
+require 'rake/testtask'
 
-task :default => 'test'
+task default: 'test'
 
 Rake::TestTask.new do |t|
-  t.libs << "lib"
-  t.test_files = Dir["test/**/*_test.rb"]
+  t.libs << 'lib'
+  t.test_files = Dir['test/**/*_test.rb']
 end

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "text_parser"
+require 'bundler/setup'
+require 'text_parser'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,5 @@ require "text_parser"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/lib/text_parser.rb
+++ b/lib/text_parser.rb
@@ -1,12 +1,14 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require_relative 'text_parser/version'
 
 module TextParser
   TEXT_PARSER_OPTIONS = {
-    :order => :word,
-    :order_direction => :asc,
-    :order_style => :ignore_accents,
-    :negative_dictionary => []
+    order: :word,
+    order_direction: :asc,
+    order_style: :ignore_accents,
+    negative_dictionary: []
   }.freeze
 
   # Returns a parsed text with the words and its occurrences.
@@ -20,11 +22,11 @@ module TextParser
     options[:dictionary] = text.split(' ') unless options[:dictionary]
     return [] if options[:dictionary].count < 1
     regex = Regexp.new(options[:dictionary].join('\\b|\\b'), Regexp::IGNORECASE)
-    match_result = text.scan(regex).map{|i| i.downcase}
-    match_result = match_result.select{|i| i.size >= options[:minimum_length]} if options[:minimum_length]
+    match_result = text.scan(regex).map { |i| i.downcase }
+    match_result = match_result.select { |i| i.size >= options[:minimum_length] } if options[:minimum_length]
     result = []
     match_result.each do |w|
-      result << { :hits => match_result.count(w), :word => w } unless result.select { |r| r[:word] == w}.shift || options[:negative_dictionary].map{|i| i.downcase }.include?(w)
+      result << { hits: match_result.count(w), word: w } unless result.select { |r| r[:word] == w}.shift || options[:negative_dictionary].map { |i| i.downcase }.include?(w)
     end
 
     result.sort_by! do |i|

--- a/lib/text_parser/version.rb
+++ b/lib/text_parser/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TextParser
-  VERSION = "0.3.0"
+  VERSION = '0.3.1'
 end

--- a/test/text_parser_test.rb
+++ b/test/text_parser_test.rb
@@ -1,108 +1,128 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require 'test/unit'
 require 'text_parser'
 
 class TextParserTest < Test::Unit::TestCase
   def test_should_have_method_parse
-    assert "string".respond_to?(:parse)
+    assert 'string'.respond_to?(:parse)
   end
 
   def test_should_parse
-    text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium consectetur."
-    assert_equal [{:word => "consectetur",  :hits => 2},
-                  {:word => "dolor",        :hits => 1}],
-                  text.parse(:dictionary => ["dolor", "consectetur"])
+    text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium consectetur.'
+    assert_equal [
+      { word: 'consectetur', hits: 2 },
+      { word: 'dolor', hits: 1 }
+    ],
+
+    text.parse(dictionary: ['dolor', 'consectetur'])
   end
 
   def test_should_parse_without_dictionary
-    assert_equal [{:word => "test", :hits => 2}], "test test".parse
+    assert_equal [{ word: 'test', hits: 2 }], 'test test'.parse
   end
 
   def test_should_remove_some_characters
-    text = "Test? Test. Yes, test!"
-    assert_equal [{:word => "test", :hits => 3}, {:word => "yes", :hits => 1}], text.parse
+    text = 'Test? Test. Yes, test!'
+
+    assert_equal [{ word: 'test', hits: 3 }, { word: 'yes', hits: 1 }], text.parse
   end
 
   def test_should_return_an_empty_array
-    assert_equal "test".parse(:dictionary => ['abc']), []
+    assert_equal 'test'.parse(dictionary: ['abc']), []
   end
 
   def test_should_order_by_word_asc
     text = ' beta omega gamma alpha gamma'
-    result = [{:word => "alpha",  :hits => 1},
-              {:word => "beta",   :hits => 1},
-              {:word => "gamma",  :hits => 2},
-              {:word => "omega",  :hits => 1}]
+    result = [
+      { word: 'alpha', hits: 1 },
+      { word: 'beta', hits: 1 },
+      { word: 'gamma', hits: 2 },
+      { word: 'omega', hits: 1 }
+    ]
+
     assert_equal result, text.parse
-    assert_equal result, text.parse(:order => :word)
-    assert_equal result, text.parse(:order => :word, :order_direction => :asc)
+    assert_equal result, text.parse(order: :word)
+    assert_equal result, text.parse(order: :word, order_direction: :asc)
   end
 
   def test_should_order_by_word_desc
-    assert_equal [{:word => "zzz",  :hits => 1},
-                  {:word => "aaa",  :hits => 1}], 'aaa zzz'.parse(:order => :word, :order_direction => :desc)
+    result = [
+      { word: 'zzz', hits: 1 },
+      { word: 'aaa', hits: 1 }
+    ]
+
+    assert_equal result, 'aaa zzz'.parse(order: :word, order_direction: :desc)
   end
 
   def test_should_order_ignoring_accents
     text = 'bílis ômega gato astuto árvore amora gato'
     result = [
-      { :word => 'amora', :hits => 1 },
-      { :word => 'árvore', :hits => 1 },
-      { :word => 'astuto', :hits => 1 },
-      { :word => 'bílis', :hits => 1 },
-      { :word => 'gato', :hits => 2 },
-      { :word => 'ômega', :hits => 1 }
+      { word: 'amora', hits: 1 },
+      { word: 'árvore', hits: 1 },
+      { word: 'astuto', hits: 1 },
+      { word: 'bílis', hits: 1 },
+      { word: 'gato', hits: 2 },
+      { word: 'ômega', hits: 1 }
     ]
 
-    assert_equal result, text.parse(:order => :word, :order_style => :ignore_accents)
+    assert_equal result, text.parse(order: :word, order_style: :ignore_accents)
   end
 
   def test_should_order_ignoring_accents_desc
     text = 'bílis ômega gato árvore amora gato'
     result = [
-      { :word => 'ômega', :hits => 1 },
-      { :word => 'gato', :hits => 2 },
-      { :word => 'bílis', :hits => 1 },
-      { :word => 'árvore', :hits => 1 },
-      { :word => 'amora', :hits => 1 }
+      { word: 'ômega', hits: 1 },
+      { word: 'gato', hits: 2 },
+      { word: 'bílis', hits: 1 },
+      { word: 'árvore', hits: 1 },
+      { word: 'amora', hits: 1 }
     ]
 
-    assert_equal result, text.parse(:order => :word, :order_style => :ignore_accents, :order_direction => :desc)
+    assert_equal result, text.parse(order: :word, order_style: :ignore_accents, order_direction: :desc)
   end
 
   def test_should_not_ignore_accents_if_ordered_field_is_not_string
     text = 'bílis ômega gato astuto árvore amora gato'
     result = [
-      { :word => 'gato', :hits => 2 },
-      { :word => 'amora', :hits => 1 },
-      { :word => 'árvore', :hits => 1 },
-      { :word => 'astuto', :hits => 1 },
-      { :word => 'bílis', :hits => 1 },
-      { :word => 'ômega', :hits => 1 }
+      { word: 'gato', hits: 2 },
+      { word: 'amora', hits: 1 },
+      { word: 'árvore', hits: 1 },
+      { word: 'astuto', hits: 1 },
+      { word: 'bílis', hits: 1 },
+      { word: 'ômega', hits: 1 }
     ]
-    parsed_text = text.parse(:order => :hits, :order_style => :ignore_accents, :order_direction => :desc)
+    parsed_text = text.parse(order: :hits, order_style: :ignore_accents, order_direction: :desc)
+
     assert_equal 'gato', parsed_text.first[:word]
   end
 
   def test_should_order_by_hits_asc
-    text = "gamma alpha gamma beta alpha gamma"
-    result = [{:word => "beta",  :hits => 1},
-              {:word => "alpha", :hits => 2},
-              {:word => "gamma", :hits => 3}]
-    assert_equal result, text.parse(:order => :hits)
-    assert_equal result, text.parse(:order => :hits, :order_direction => :asc)
+    text = 'gamma alpha gamma beta alpha gamma'
+    result = [
+      { word: 'beta', hits: 1 },
+      { word: 'alpha', hits: 2 },
+      { word: 'gamma', hits: 3 }
+    ]
+
+    assert_equal result, text.parse(order: :hits)
+    assert_equal result, text.parse(order: :hits, order_direction: :asc)
   end
 
   def test_should_order_by_hits_desc
-    text = "gamma alpha gamma beta alpha gamma"
-    assert_equal [{:word => "gamma",  :hits => 3},
-                  {:word => "alpha",  :hits => 2},
-                  {:word => "beta",   :hits => 1}],
-                  text.parse(:order => :hits, :order_direction => :desc)
+    text = 'gamma alpha gamma beta alpha gamma'
+    result = [
+      { word: 'gamma', hits: 3 },
+      { word: 'alpha', hits: 2 },
+      { word: 'beta', hits: 1 }
+    ]
+
+    assert_equal result, text.parse(order: :hits, order_direction: :desc)
   end
 
   def test_should_ignore_negative_dictionary
-    assert_equal [{:word => "good",  :hits => 1}], "This is good".parse(:negative_dictionary => ["is", "this"])
+    assert_equal [{ word: 'good', hits: 1 }], 'This is good'.parse(negative_dictionary: ['is', 'this'])
   end
 
   def test_should_works_with_special_characters
@@ -110,46 +130,52 @@ class TextParserTest < Test::Unit::TestCase
   end
 
   def test_should_works_hifen
-    assert_equal [{:word => "self-service", :hits => 1}], "self-service".parse
+    assert_equal [{ word: 'self-service', hits: 1 }], 'self-service'.parse
   end
 
   def test_should_return_double_words
-    assert_equal [{:word => "forrest gump", :hits => 1}],
-                 "I like the movie Forrest Gump.".parse(:dictionary => ["Forrest Gump"])
+    result = [{ word: 'forrest gump', hits: 1 }]
+    assert_equal result, 'I like the movie Forrest Gump.'.parse(dictionary: ['Forrest Gump'])
   end
 
   def test_should_manage_null_args
-    args = {:dictionary=>nil, :negative_dictionary=>nil, :order=>nil, :order_direction=>nil}
-    assert_equal [{:word => "text", :hits => 1}], "text".parse(args)
+    args = { dictionary: nil, negative_dictionary: nil, order: nil, order_direction: nil }
+    assert_equal [{ word: 'text', hits: 1 }], 'text'.parse(args)
   end
 
   def test_should_work_with_many_spaces
     text = "e se    eu     encher      de    espacos"
-    assert_equal [{:word => "de",     :hits => 1},
-                  {:word => "e",      :hits => 1},
-                  {:word => "encher", :hits => 1},
-                  {:word => "espacos",:hits => 1},
-                  {:word => "eu",     :hits => 1},
-                  {:word => "se",     :hits => 1}], text.parse
+    result = [
+      { word: 'de', hits: 1 },
+      { word: 'e', hits: 1 },
+      { word: 'encher', hits: 1 },
+      { word: 'espacos', hits: 1 },
+      { word: 'eu', hits: 1 },
+      { word: 'se', hits: 1 }
+    ]
+
+    assert_equal result, text.parse
   end
 
   def test_should_keep_some_special_character
-    assert_equal [{:word => "espaço", :hits => 1},
-                  {:word => "sideral",:hits => 1}], "Espaço sideral".parse
-    assert_equal [{:word => "açúcar", :hits => 1},
-                  {:word => "pão",    :hits => 1}], "Pão açúcar".parse
-    assert_equal [{:word => "ãéç",    :hits => 1}], "ãéç".parse
+    assert_equal [{ word: 'espaço', hits: 1 },
+                  { word: 'sideral', hits: 1 }], 'Espaço sideral'.parse
+
+    assert_equal [{ word: 'açúcar', hits: 1 },
+                  { word: 'pão', hits: 1 }], 'Pão açúcar'.parse
+
+    assert_equal [{ word: 'ãéç', hits: 1 }], 'ãéç'.parse
   end
 
   def test_minimum_length
-    text = "a ab   abc "
-    assert_equal [{:word => "a",    :hits => 1},
-                  {:word => "ab",   :hits => 1},
-                  {:word => "abc",  :hits => 1}], text.parse(:minimum_length => 1)
-    assert_equal [{:word => "ab",   :hits => 1},
-                  {:word => "abc",  :hits => 1}], text.parse(:minimum_length => 2)
-    assert_equal [{:word => "abc",  :hits => 1}], text.parse(:minimum_length => 3)
-    assert_equal [{:word => "abc",  :hits => 1}], text.parse(:minimum_length => 2, :negative_dictionary => ["ab"])
-    assert_equal [],                              text.parse(:minimum_length => 3, :dictionary => ["a"])
+    text = 'a ab   abc '
+    assert_equal [{ word: 'a', hits: 1 },
+                  { word: 'ab', hits: 1 },
+                  { word: 'abc', hits: 1 }], text.parse(minimum_length: 1)
+    assert_equal [{ word: 'ab', hits: 1 },
+                  { word: 'abc', hits: 1 }], text.parse(minimum_length: 2)
+    assert_equal [{ word: 'abc', hits: 1 }], text.parse(minimum_length: 3)
+    assert_equal [{ word: 'abc', hits: 1 }], text.parse(minimum_length: 2, negative_dictionary: ['ab'])
+    assert_equal [], text.parse(minimum_length: 3, dictionary: ['a'])
   end
 end

--- a/text_parser.gemspec
+++ b/text_parser.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'test-unit', '~> 3.2'
+
+  spec.required_ruby_version = '>= 1.9.2'
 end


### PR DESCRIPTION
This PR makes ruby 1.9.2 or above required and changes hashes to use the new ruby code style (without the rockets)